### PR TITLE
docs: add Developer Mode Toggle note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ React application used for:
 
 The UI runs in a browser and is designed to later run inside a **mobile WebView wrapper**.
 
+### Developer Mode Toggle
+
+The UI includes a **Developer Mode toggle** intended for local development and QA workflows.
+
+When enabled, it uses browser storage options to seed/populate interface state so developers can quickly load realistic UI scenarios for testing without requiring live backend data.
+
 ### 2. API Layer
 
 FastAPI service responsible for:


### PR DESCRIPTION
### Motivation
- Clarify that the UI's Developer Mode toggle is intended for local development and QA and will use browser storage to seed UI state for testing without requiring live backend data.

### Description
- Add a `Developer Mode Toggle` subsection to the UI Layer in `README.md` that documents the toggle and explains it uses browser storage options to populate interface state for testing.

### Testing
- Documentation-only change; validated locally with `git status --short`, `git diff -- README.md`, and committing the update, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b59019cbe48333bcf46694e116aaa9)