### PR TITLE
Create app shell layout with session-scoped developer mode

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -1,41 +1,10 @@
-import { DeveloperModeProvider } from './context/developer-mode-context'
-import { DeveloperModeToggle } from './components/developer-mode-toggle'
-
-const TopBar = () => {
-  return (
-    <header
-      id="topbar-root"
-      className="flex min-h-16 items-center justify-between border-b border-slate-200 bg-white px-4 py-3"
-    >
-      <h1 id="topbar-project-title" className="text-lg font-semibold text-slate-900">
-        Malcom Middleware
-      </h1>
-      <div id="topbar-system-status" className="flex items-center gap-4">
-        <span id="topbar-system-status-indicator" className="rounded bg-emerald-50 px-2 py-1 text-xs font-medium text-emerald-700">
-          System healthy
-        </span>
-        <DeveloperModeToggle />
-      </div>
-    </header>
-  )
-}
+import { DeveloperModeProvider } from './context/DeveloperModeContext'
+import { AppShell } from './layout/AppShell'
 
 export const App = () => {
   return (
     <DeveloperModeProvider>
-      <div id="app-shell" className="min-h-screen bg-slate-50 text-slate-900">
-        <TopBar />
-        <main id="home-main-content" className="p-4">
-          <section id="home-intro-panel" className="rounded border border-slate-200 bg-white p-4">
-            <h2 id="home-intro-title" className="text-base font-semibold">
-              UI Step 1: Developer Mode Toggle
-            </h2>
-            <p id="home-intro-description" className="mt-2 text-sm text-slate-600">
-              This toggle is session-scoped and is intended for safe testing with mock data.
-            </p>
-          </section>
-        </main>
-      </div>
+      <AppShell />
     </DeveloperModeProvider>
   )
 }

--- a/ui/src/context/DeveloperModeContext.jsx
+++ b/ui/src/context/DeveloperModeContext.jsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+
+const STORAGE_KEY = 'developerMode'
+
+const readInitialDeveloperMode = () => {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  return window.sessionStorage.getItem(STORAGE_KEY) === 'true'
+}
+
+const DeveloperModeContext = createContext({
+  developerMode: false,
+  setDeveloperMode: () => {}
+})
+
+export const DeveloperModeProvider = ({ children }) => {
+  const [developerMode, setDeveloperMode] = useState(readInitialDeveloperMode)
+
+  useEffect(() => {
+    window.sessionStorage.setItem(STORAGE_KEY, String(developerMode))
+  }, [developerMode])
+
+  const value = useMemo(
+    () => ({
+      developerMode,
+      setDeveloperMode
+    }),
+    [developerMode]
+  )
+
+  return <DeveloperModeContext.Provider value={value}>{children}</DeveloperModeContext.Provider>
+}
+
+export const useDeveloperMode = () => useContext(DeveloperModeContext)

--- a/ui/src/layout/AppShell.tsx
+++ b/ui/src/layout/AppShell.tsx
@@ -1,0 +1,23 @@
+import { TopBar } from './TopBar'
+import { Sidebar } from './Sidebar'
+
+export const AppShell = () => {
+  return (
+    <div id="app-shell" className="min-h-screen bg-slate-50 text-slate-900">
+      <TopBar />
+      <div id="app-shell-body" className="flex min-h-[calc(100vh-3.5rem)]">
+        <Sidebar />
+        <main id="app-main" className="flex-1 p-4">
+          <section id="home-intro-panel" className="rounded border border-slate-200 bg-white p-4">
+            <h2 id="home-intro-title" className="text-sm font-semibold text-slate-900">
+              Middleware Operations Workspace
+            </h2>
+            <p id="home-intro-description" className="mt-2 text-sm text-slate-600">
+              Use the Developer mode switch to choose mock or live behavior for this browser session.
+            </p>
+          </section>
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/layout/Sidebar.tsx
+++ b/ui/src/layout/Sidebar.tsx
@@ -1,0 +1,25 @@
+export const Sidebar = () => {
+  return (
+    <aside
+      id="sidebar-root"
+      className="w-56 shrink-0 border-r border-slate-200 bg-slate-100/70 px-3 py-3"
+      aria-label="Primary navigation"
+    >
+      <nav id="sidebar-nav" className="space-y-1">
+        <a
+          id="sidebar-nav-dashboard"
+          href="#"
+          className="block rounded border border-slate-300 bg-white px-2 py-1.5 text-xs font-medium text-slate-800"
+        >
+          Dashboard
+        </a>
+        <a id="sidebar-nav-agents" href="#" className="block rounded px-2 py-1.5 text-xs text-slate-600 hover:bg-slate-200">
+          Agents
+        </a>
+        <a id="sidebar-nav-runs" href="#" className="block rounded px-2 py-1.5 text-xs text-slate-600 hover:bg-slate-200">
+          Runs
+        </a>
+      </nav>
+    </aside>
+  )
+}

--- a/ui/src/layout/TopBar.tsx
+++ b/ui/src/layout/TopBar.tsx
@@ -1,0 +1,51 @@
+import * as Switch from '@radix-ui/react-switch'
+import { useDeveloperMode } from '../context/DeveloperModeContext'
+
+export const TopBar = () => {
+  const { developerMode, setDeveloperMode } = useDeveloperMode()
+
+  return (
+    <header
+      id="topbar-root"
+      className="flex h-14 items-center justify-between border-b border-slate-200 bg-white px-4"
+    >
+      <h1 id="topbar-project-title" className="text-sm font-semibold tracking-wide text-slate-900">
+        Malcom Middleware Console
+      </h1>
+
+      <div id="topbar-controls" className="flex items-center gap-3">
+        <span
+          id="topbar-system-status"
+          className="rounded border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700"
+        >
+          System healthy
+        </span>
+
+        <div id="topbar-developer-mode-group" className="flex items-center gap-2">
+          <label
+            id="topbar-developer-mode-label"
+            htmlFor="topbar-developer-mode-toggle"
+            className="text-xs font-medium text-slate-700"
+          >
+            Developer mode
+          </label>
+          <Switch.Root
+            id="topbar-developer-mode-toggle"
+            checked={developerMode}
+            onCheckedChange={setDeveloperMode}
+            aria-label="Toggle developer mode"
+            className="relative h-5 w-10 rounded-full border border-slate-300 bg-slate-200 transition data-[state=checked]:border-indigo-600 data-[state=checked]:bg-indigo-600"
+          >
+            <Switch.Thumb
+              id="topbar-developer-mode-toggle-thumb"
+              className="block h-4 w-4 translate-x-0.5 rounded-full bg-white transition-transform data-[state=checked]:translate-x-[1.1rem]"
+            />
+          </Switch.Root>
+          <span id="topbar-developer-mode-state" className="text-xs text-slate-500" aria-live="polite">
+            {developerMode ? 'Mock' : 'Live'}
+          </span>
+        </div>
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
### Motivation
- Establish a compact, admin-oriented React UI shell so future pages and automation hooks have stable structure and IDs.
- Provide a session-scoped Developer Mode toggle so pages can switch between mock and live behavior without persisting across browser sessions.
- Ensure all top-bar elements expose stable, deterministic IDs for automation and UI testing hooks as required by the agent guidelines.

### Description
- Added a `DeveloperModeContext` provider and `useDeveloperMode` hook persisted to `sessionStorage` under key `developerMode` at `ui/src/context/DeveloperModeContext.jsx`.
- Replaced the inline top bar with a layout-based shell and updated `ui/src/App.jsx` to render `AppShell` wrapped by `DeveloperModeProvider`.
- Created layout components `AppShell`, `TopBar`, and `Sidebar` at `ui/src/layout/AppShell.tsx`, `ui/src/layout/TopBar.tsx`, and `ui/src/layout/Sidebar.tsx` with compact Tailwind light-mode styling.
- Wired the top bar switch to context state and added explicit stable IDs required for automation and testing, including `topbar-root`, `topbar-project-title`, `topbar-system-status`, and `topbar-developer-mode-toggle`.

### Testing
- Ran `npm install` inside `ui` and it failed due to a `403 Forbidden` from the npm registry for `@radix-ui/react-switch`, so dependencies were not installed and further toolchain tasks could not run. (failed)
- Ran `npm test` (`vitest`) and it failed because `vitest` was not available before dependencies were installed. (failed)
- Ran `npm run build` (`vite`) and it failed because `vite` was not available before dependencies were installed. (failed)
- Attempted an automated Playwright screenshot against the dev server at `http://127.0.0.1:5173` and it failed with `ERR_EMPTY_RESPONSE` because no dev server was running in this environment. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5921a1f4c8333ac346ff145c4ec34)