### PR TITLE
Add automation run tracking schema, lifecycle recording, and runs API

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -97,6 +97,30 @@ def initialize(connection: sqlite3.Connection) -> None:
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
+
+        CREATE TABLE IF NOT EXISTS automation_runs (
+            run_id TEXT PRIMARY KEY,
+            automation_id TEXT NOT NULL,
+            trigger_type TEXT NOT NULL,
+            status TEXT NOT NULL,
+            started_at TEXT NOT NULL,
+            finished_at TEXT,
+            duration_ms INTEGER,
+            error_summary TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS automation_run_steps (
+            step_id TEXT PRIMARY KEY,
+            run_id TEXT NOT NULL REFERENCES automation_runs(run_id) ON DELETE CASCADE,
+            step_name TEXT NOT NULL,
+            status TEXT NOT NULL,
+            request_summary TEXT,
+            response_summary TEXT,
+            started_at TEXT NOT NULL,
+            finished_at TEXT,
+            duration_ms INTEGER,
+            detail_json TEXT
+        );
         """
     )
     _ensure_column(connection, "inbound_apis", "is_mock", "INTEGER NOT NULL DEFAULT 0")

--- a/backend/main.py
+++ b/backend/main.py
@@ -271,6 +271,35 @@ def row_to_event(row: sqlite3.Row) -> dict[str, Any]:
     }
 
 
+
+
+def row_to_run(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "run_id": row["run_id"],
+        "automation_id": row["automation_id"],
+        "trigger_type": row["trigger_type"],
+        "status": row["status"],
+        "started_at": row["started_at"],
+        "finished_at": row["finished_at"],
+        "duration_ms": row["duration_ms"],
+        "error_summary": row["error_summary"],
+    }
+
+
+def row_to_run_step(row: sqlite3.Row) -> dict[str, Any]:
+    detail_json = row["detail_json"]
+    return {
+        "step_id": row["step_id"],
+        "run_id": row["run_id"],
+        "step_name": row["step_name"],
+        "status": row["status"],
+        "request_summary": row["request_summary"],
+        "response_summary": row["response_summary"],
+        "started_at": row["started_at"],
+        "finished_at": row["finished_at"],
+        "duration_ms": row["duration_ms"],
+        "detail_json": json.loads(detail_json) if detail_json else None,
+    }
 def row_to_simple_api_resource(
     row: sqlite3.Row,
     *,
@@ -432,6 +461,34 @@ class InboundApiDetail(InboundApiResponse):
     events: list[dict[str, Any]]
 
 
+
+
+class AutomationRunStepResponse(BaseModel):
+    step_id: str
+    run_id: str
+    step_name: str
+    status: str
+    request_summary: str | None
+    response_summary: str | None
+    started_at: str
+    finished_at: str | None
+    duration_ms: int | None
+    detail_json: dict[str, Any] | None
+
+
+class AutomationRunResponse(BaseModel):
+    run_id: str
+    automation_id: str
+    trigger_type: str
+    status: str
+    started_at: str
+    finished_at: str | None
+    duration_ms: int | None
+    error_summary: str | None
+
+
+class AutomationRunDetailResponse(AutomationRunResponse):
+    steps: list[AutomationRunStepResponse]
 class ToolMetadataResponse(BaseModel):
     id: str
     name: str
@@ -736,6 +793,134 @@ def log_event(
     connection.commit()
 
 
+
+
+def calculate_duration_ms(started_at: str, finished_at: str) -> int:
+    started = datetime.fromisoformat(started_at)
+    finished = datetime.fromisoformat(finished_at)
+    return max(int((finished - started).total_seconds() * 1000), 0)
+
+
+def create_automation_run(
+    connection: sqlite3.Connection,
+    *,
+    run_id: str,
+    automation_id: str,
+    trigger_type: str,
+    status_value: str,
+    started_at: str,
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO automation_runs (
+            run_id,
+            automation_id,
+            trigger_type,
+            status,
+            started_at,
+            finished_at,
+            duration_ms,
+            error_summary
+        ) VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL)
+        """,
+        (run_id, automation_id, trigger_type, status_value, started_at),
+    )
+    connection.commit()
+
+
+def create_automation_run_step(
+    connection: sqlite3.Connection,
+    *,
+    step_id: str,
+    run_id: str,
+    step_name: str,
+    status_value: str,
+    request_summary: str | None,
+    started_at: str,
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO automation_run_steps (
+            step_id,
+            run_id,
+            step_name,
+            status,
+            request_summary,
+            response_summary,
+            started_at,
+            finished_at,
+            duration_ms,
+            detail_json
+        ) VALUES (?, ?, ?, ?, ?, NULL, ?, NULL, NULL, NULL)
+        """,
+        (step_id, run_id, step_name, status_value, request_summary, started_at),
+    )
+    connection.commit()
+
+
+def finalize_automation_run_step(
+    connection: sqlite3.Connection,
+    *,
+    step_id: str,
+    status_value: str,
+    response_summary: str | None,
+    detail: dict[str, Any] | None,
+    finished_at: str,
+) -> None:
+    step_row = fetch_one(connection, "SELECT started_at FROM automation_run_steps WHERE step_id = ?", (step_id,))
+
+    if step_row is None:
+        return
+
+    duration_ms = calculate_duration_ms(step_row["started_at"], finished_at)
+    connection.execute(
+        """
+        UPDATE automation_run_steps
+        SET status = ?,
+            response_summary = ?,
+            finished_at = ?,
+            duration_ms = ?,
+            detail_json = ?
+        WHERE step_id = ?
+        """,
+        (
+            status_value,
+            response_summary,
+            finished_at,
+            duration_ms,
+            json.dumps(detail) if detail is not None else None,
+            step_id,
+        ),
+    )
+    connection.commit()
+
+
+def finalize_automation_run(
+    connection: sqlite3.Connection,
+    *,
+    run_id: str,
+    status_value: str,
+    error_summary: str | None,
+    finished_at: str,
+) -> None:
+    run_row = fetch_one(connection, "SELECT started_at FROM automation_runs WHERE run_id = ?", (run_id,))
+
+    if run_row is None:
+        return
+
+    duration_ms = calculate_duration_ms(run_row["started_at"], finished_at)
+    connection.execute(
+        """
+        UPDATE automation_runs
+        SET status = ?,
+            finished_at = ?,
+            duration_ms = ?,
+            error_summary = ?
+        WHERE run_id = ?
+        """,
+        (status_value, finished_at, duration_ms, error_summary, run_id),
+    )
+    connection.commit()
 @app.get("/health")
 def healthcheck() -> dict[str, str]:
     return {"status": "ok"}
@@ -1255,7 +1440,45 @@ async def receive_inbound_event(api_id: str, request: Request, response: Respons
         payload=payload,
         received_at=received_at,
     )
+
+    run_id = f"run_{uuid4().hex}"
+    step_id = f"step_{uuid4().hex}"
+    create_automation_run(
+        connection,
+        run_id=run_id,
+        automation_id=api_id,
+        trigger_type=trigger.type,
+        status_value="running",
+        started_at=received_at,
+    )
+    create_automation_run_step(
+        connection,
+        step_id=step_id,
+        run_id=run_id,
+        step_name="emit_runtime_trigger",
+        status_value="running",
+        request_summary=f"event_id={event_id}",
+        started_at=received_at,
+    )
+
+    finished_at = utc_now_iso()
     runtime_event_bus.emit(trigger)
+    finalize_automation_run_step(
+        connection,
+        step_id=step_id,
+        status_value="completed",
+        response_summary="Trigger emitted to runtime event bus.",
+        detail={"event_id": event_id, "api_id": api_id},
+        finished_at=finished_at,
+    )
+    finalize_automation_run(
+        connection,
+        run_id=run_id,
+        status_value="completed",
+        error_summary=None,
+        finished_at=finished_at,
+    )
+
     response.headers["X-Malcom-Event-Id"] = event_id
     return InboundReceiveAccepted(
         status="accepted",
@@ -1270,6 +1493,106 @@ async def receive_inbound_event(api_id: str, request: Request, response: Respons
     )
 
 
+
+
+@app.get("/api/v1/runs", response_model=list[AutomationRunResponse])
+def list_automation_runs(
+    request: Request,
+    status: str | None = None,
+    automation_id: str | None = None,
+    started_after: str | None = None,
+    started_before: str | None = None,
+) -> list[AutomationRunResponse]:
+    connection = get_connection(request)
+    where_clauses: list[str] = []
+    params: list[Any] = []
+
+    if status is not None:
+        where_clauses.append("status = ?")
+        params.append(status)
+
+    if automation_id is not None:
+        where_clauses.append("automation_id = ?")
+        params.append(automation_id)
+
+    if started_after is not None:
+        where_clauses.append("started_at >= ?")
+        params.append(started_after)
+
+    if started_before is not None:
+        where_clauses.append("started_at <= ?")
+        params.append(started_before)
+
+    where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+    rows = fetch_all(
+        connection,
+        f"""
+        SELECT
+            run_id,
+            automation_id,
+            trigger_type,
+            status,
+            started_at,
+            finished_at,
+            duration_ms,
+            error_summary
+        FROM automation_runs
+        {where_sql}
+        ORDER BY started_at DESC
+        """,
+        tuple(params),
+    )
+    return [AutomationRunResponse(**row_to_run(row)) for row in rows]
+
+
+@app.get("/api/v1/runs/{run_id}", response_model=AutomationRunDetailResponse)
+def get_automation_run(run_id: str, request: Request) -> AutomationRunDetailResponse:
+    connection = get_connection(request)
+    run_row = fetch_one(
+        connection,
+        """
+        SELECT
+            run_id,
+            automation_id,
+            trigger_type,
+            status,
+            started_at,
+            finished_at,
+            duration_ms,
+            error_summary
+        FROM automation_runs
+        WHERE run_id = ?
+        """,
+        (run_id,),
+    )
+
+    if run_row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Automation run not found.")
+
+    step_rows = fetch_all(
+        connection,
+        """
+        SELECT
+            step_id,
+            run_id,
+            step_name,
+            status,
+            request_summary,
+            response_summary,
+            started_at,
+            finished_at,
+            duration_ms,
+            detail_json
+        FROM automation_run_steps
+        WHERE run_id = ?
+        ORDER BY started_at ASC
+        """,
+        (run_id,),
+    )
+
+    detail = row_to_run(run_row)
+    detail["steps"] = [row_to_run_step(step_row) for step_row in step_rows]
+    return AutomationRunDetailResponse(**detail)
 @app.get("/api/v1/runtime/triggers")
 def list_runtime_triggers() -> list[dict[str, Any]]:
     return [

--- a/tests/test_runs_api.py
+++ b/tests/test_runs_api.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+
+class AutomationRunsApiTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        app.state.db_path = str(Path(self.tempdir.name) / "malcom-test.db")
+        self.client = TestClient(app)
+        self.client.__enter__()
+
+    def tearDown(self) -> None:
+        self.client.__exit__(None, None, None)
+        self.tempdir.cleanup()
+
+    def create_inbound_api(self, slug: str) -> dict:
+        response = self.client.post(
+            "/api/v1/inbound",
+            json={
+                "name": f"{slug} webhook",
+                "description": "Receives events.",
+                "path_slug": slug,
+                "enabled": True,
+            },
+        )
+        self.assertEqual(response.status_code, 201)
+        return response.json()
+
+    def emit_run(self, api: dict, payload: dict) -> None:
+        response = self.client.post(
+            f"/api/v1/inbound/{api['id']}",
+            headers={
+                "Authorization": f"Bearer {api['secret']}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+        )
+        self.assertEqual(response.status_code, 202)
+
+    def test_list_runs_ordering_and_filters(self) -> None:
+        first_api = self.create_inbound_api("first-run-source")
+        second_api = self.create_inbound_api("second-run-source")
+
+        self.emit_run(first_api, {"id": 1})
+        self.emit_run(second_api, {"id": 2})
+
+        all_runs_response = self.client.get("/api/v1/runs")
+        self.assertEqual(all_runs_response.status_code, 200)
+        all_runs = all_runs_response.json()
+        self.assertEqual(len(all_runs), 2)
+
+        self.assertGreaterEqual(all_runs[0]["started_at"], all_runs[1]["started_at"])
+
+        status_filtered = self.client.get("/api/v1/runs", params={"status": "completed"})
+        self.assertEqual(status_filtered.status_code, 200)
+        self.assertEqual(len(status_filtered.json()), 2)
+
+        automation_filtered = self.client.get(
+            "/api/v1/runs",
+            params={"automation_id": first_api["id"]},
+        )
+        self.assertEqual(automation_filtered.status_code, 200)
+        self.assertEqual(len(automation_filtered.json()), 1)
+        self.assertEqual(automation_filtered.json()[0]["automation_id"], first_api["id"])
+
+        started_before = all_runs[0]["started_at"]
+        time_filtered = self.client.get(
+            "/api/v1/runs",
+            params={"started_before": started_before},
+        )
+        self.assertEqual(time_filtered.status_code, 200)
+        self.assertGreaterEqual(len(time_filtered.json()), 1)
+
+        none_filtered = self.client.get(
+            "/api/v1/runs",
+            params={"started_after": "9999-01-01T00:00:00+00:00"},
+        )
+        self.assertEqual(none_filtered.status_code, 200)
+        self.assertEqual(none_filtered.json(), [])
+
+    def test_get_run_detail_response_contract(self) -> None:
+        api = self.create_inbound_api("detail-run-source")
+        self.emit_run(api, {"id": 123})
+
+        runs_response = self.client.get("/api/v1/runs")
+        self.assertEqual(runs_response.status_code, 200)
+        run = runs_response.json()[0]
+
+        detail_response = self.client.get(f"/api/v1/runs/{run['run_id']}")
+        self.assertEqual(detail_response.status_code, 200)
+        detail = detail_response.json()
+
+        self.assertEqual(detail["run_id"], run["run_id"])
+        self.assertEqual(detail["automation_id"], api["id"])
+        self.assertEqual(detail["trigger_type"], "inbound_api")
+        self.assertEqual(detail["status"], "completed")
+        self.assertIsInstance(detail["duration_ms"], int)
+        self.assertEqual(detail["error_summary"], None)
+        self.assertEqual(len(detail["steps"]), 1)
+
+        step = detail["steps"][0]
+        self.assertEqual(step["run_id"], detail["run_id"])
+        self.assertEqual(step["step_name"], "emit_runtime_trigger")
+        self.assertEqual(step["status"], "completed")
+        self.assertIn("event_id=", step["request_summary"])
+        self.assertEqual(step["response_summary"], "Trigger emitted to runtime event bus.")
+        self.assertIsInstance(step["detail_json"], dict)
+        self.assertIn("event_id", step["detail_json"])
+
+    def test_get_run_detail_404_for_unknown_run(self) -> None:
+        response = self.client.get("/api/v1/runs/run_missing")
+        self.assertEqual(response.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide structured recording of automation executions and their individual steps so runs can be inspected, filtered, and correlated with inbound triggers. 
- Surface run and step metadata through the API to enable UI views and automated validation of run lifecycle and timing.

### Description
- Extended the SQLite schema by adding `automation_runs` and `automation_run_steps` tables with lifecycle fields and a cascade FK from steps to runs (in `backend/database.py`).
- Added serialization helpers `row_to_run` and `row_to_run_step` and Pydantic response models `AutomationRunResponse`, `AutomationRunDetailResponse`, and `AutomationRunStepResponse` to `backend/main.py`.
- Implemented run/step lifecycle helpers (`create_automation_run`, `create_automation_run_step`, `finalize_automation_run_step`, `finalize_automation_run`, and `calculate_duration_ms`) and integrated them into inbound trigger processing to record start/finish and duration around the runtime event emission in `backend/main.py`.
- Added API endpoints `GET /api/v1/runs` (with optional `status`, `automation_id`, `started_after`, `started_before` filters) and `GET /api/v1/runs/{run_id}` that returns run detail and ordered steps, and added tests in `tests/test_runs_api.py` to validate ordering, filters, and response contract.

### Testing
- Static/compile check: ran `python -m py_compile backend/main.py backend/database.py tests/test_runs_api.py` which succeeded.
- Unit tests executed with `python -m unittest tests/test_runs_api.py tests/test_inbound_api.py` in this environment but failed to run due to missing runtime dependency `fastapi` (`ModuleNotFoundError: No module named 'fastapi'`).
- To verify locally: (1) start with an environment that has project dependencies installed (e.g. `pip install -r requirements.txt` or `pip install fastapi starlette pydantic uvicorn`), (2) run the test suite with `python -m unittest tests/test_runs_api.py tests/test_inbound_api.py` and expect the new runs tests to pass, (3) create an inbound API and POST an event to `/api/v1/inbound/{api_id}`, then call `GET /api/v1/runs` to observe newest-first ordering and `GET /api/v1/runs/{run_id}` to inspect the run and its `emit_runtime_trigger` step with `request_summary`, `response_summary`, `detail_json`, and `duration_ms` populated as described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e63b5994833384188f1e17dc2f5b)